### PR TITLE
Make backport regex more specific

### DIFF
--- a/ghpro/backport.py
+++ b/ghpro/backport.py
@@ -126,7 +126,7 @@ def backport_pr(path, branch, num, project):
     return 0
 
 
-backport_re = re.compile(r"(?:[Bb]ackport|[Mm]erge).*?(\d+)(?:[^.])")
+backport_re = re.compile(r"(?:[Bb]ackport|[Mm]erge).*?\#(\d+)(?:[^.])")
 
 
 def already_backported(repo, branch, since_tag=None):


### PR DESCRIPTION
It was picking up a commit 'Merge branch 4.x from...' and attempting to find PR #4.

As far as I can see, all PR merge and backports have a `#` before the number.