### PR TITLE
Use GITHUB_ACCESS_TOKEN and fix backport-pr authorship attribution

### DIFF
--- a/ghpro/backport.py
+++ b/ghpro/backport.py
@@ -39,6 +39,7 @@ import git
 import mock
 
 from .api import (
+    get_authors,
     get_issues_list,
     get_pull_request,
     get_pull_request_files,
@@ -111,9 +112,12 @@ def backport_pr(path, branch, num, project):
         print('\nPatch did not apply. Resolve conflicts (add, not commit), then re-run `%s`' % cmd, file=sys.stderr)
         return 1
 
-    # write the commit message
+    # update the cherry picked merge commit
     msg = "Backport PR #%i: %s" % (num, title) + '\n\n' + description
-    repo.git.commit('--amend', '-s', '-m', msg)
+    authors = get_authors(pr)
+    if len(authors) > 1:
+        msg + '\n' + "".join([f"\nCo-authored-by: {a}" for a in authors[1:]])
+    repo.git.commit('--amend', '-s', '--author', authors[0], '-m', msg)
 
     print("PR #%i applied, with msg:" % num)
     print()

--- a/ghpro/stats.py
+++ b/ghpro/stats.py
@@ -72,8 +72,8 @@ def issues_closed_since(period=timedelta(days=365), project="ipython/ipython", p
     filtered = [ i for i in allclosed if _parse_datetime(i['closed_at']) > since ]
     if pulls:
         filtered = [ i for i in filtered if _parse_datetime(i['merged_at']) > since ]
-        # filter out PRs not against master (backports)
-        filtered = [ i for i in filtered if i['base']['ref'] == 'master' ]
+        # filter out PRs not against main branches (backports)
+        filtered = [ i for i in filtered if i['base']['ref'] not in ['main', 'master'] ]
     else:
         filtered = [ i for i in filtered if not is_pull_request(i) ]
     


### PR DESCRIPTION
These are three separate fixes that I ended up needing to make. I can put in some effort to make them three separate PRs to be merged in succession if wanted.

- Rely on GITHUB_ACCESS_TOKEN instead of username/password (+OTP)
  Closes #19
- Give main special treatment alongside master
- Fix attribution to authors of PRs
